### PR TITLE
Fix: Ensure website content expands to screen edges.

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,11 +17,12 @@
             line-height: 1.6;
             color: #1d1d1d;
             background-color: #ffffff;
+            overflow-x: hidden;
         }
 
         .container {
             position: relative;
-            width: 1440px;
+            width: 100%;
             height: 5701px;
             background-color: #ffffff;
         }


### PR DESCRIPTION
I modified the CSS for the main .container to have `width: 100%` instead of a fixed width, allowing it to expand to the full viewport width.
I also added `overflow-x: hidden;` to the `body` to prevent accidental horizontal scrolling.

This change ensures that the page layout, including major sections like the hero, download area, and footer, extends to the edges of the screen, particularly on wider displays, and maintains responsiveness on smaller screens.